### PR TITLE
copy `.hpp` and `.inl` to `include`

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -35,6 +35,8 @@ conan_basic_setup()''')
 
     def package(self):
         self.copy("*.h", dst="include", src="assimp-3.3.1/include")
+        self.copy("*.hpp", dst="include", src="assimp-3.3.1/include")
+        self.copy("*.inl", dst="include", src="assimp-3.3.1/include")
         self.copy("*assimp.lib", dst="lib", keep_path=False)
         self.copy("*.dll", dst="bin", keep_path=False)
         self.copy("*.so", dst="lib", keep_path=False)


### PR DESCRIPTION
Thanks @jacmoe for making this package - really great.

The `hpp` and `inl` headers weren't being copied by conan, causing failing builds.

Note: if you have `libassimp-dev` install (Ubuntu) then this error doesn't show (my, bad, test case)
